### PR TITLE
add link to article on reading session card

### DIFF
--- a/zeeguu-teacher-dashboard/src/assets/styles/pages/studentPage.scss
+++ b/zeeguu-teacher-dashboard/src/assets/styles/pages/studentPage.scss
@@ -13,6 +13,12 @@
   color: $color-text-primary-light;
 }
 
+.student-activity-item-link {
+  color: $color-link;
+  margin-left: 10px;
+  font-size: 14px;
+}
+
 .student-activity-item-duration {
   font-size: $font-size-medium;
   margin-left: auto;

--- a/zeeguu-teacher-dashboard/src/pages/StudentPage.js
+++ b/zeeguu-teacher-dashboard/src/pages/StudentPage.js
@@ -54,13 +54,25 @@ const StudentActivity = ({ studentId }) => {
           </p>
           {articlesByDate.map((day, index) => (
             <div className="student-activity" key={index}>
-              <p>{day.date}</p>
+              <p style={{ marginBottom: 10 }}>{day.date}</p>
               {day.reading_sessions.map((readingSession, index) => (
                 <ExpansionPanel key={index}>
                   <ExpansionPanelSummary expandIcon={<MdExpandMore />}>
-                    <h2 className="student-activity-item-heading">
-                      {readingSession.article_title}
-                    </h2>
+                    <div style={{ display: 'flex', alignItems: 'baseline' }}>
+                      <h2 className="student-activity-item-heading">
+                        {readingSession.article_title}
+                      </h2>
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="student-activity-item-link"
+                        href={`/read/article?articleID=${
+                          readingSession.article_id
+                        }`}
+                      >
+                        Go to article
+                      </a>
+                    </div>
                     <p className="student-activity-item-duration">
                       {sessionDuration(readingSession)}
                     </p>

--- a/zeeguu-teacher-dashboard/src/pages/StudentPage.js
+++ b/zeeguu-teacher-dashboard/src/pages/StudentPage.js
@@ -70,7 +70,7 @@ const StudentActivity = ({ studentId }) => {
                           readingSession.article_id
                         }`}
                       >
-                        Go to article
+                        (→)
                       </a>
                     </div>
                     <p className="student-activity-item-duration">


### PR DESCRIPTION
Requested: "It used to be possible to click on an article title that a student had read and the article would be put on the screen in order for the teacher to be able to read it as well."

This PR offers a slightly different solution, see screenshot below:

![image](https://user-images.githubusercontent.com/21239560/60125735-b5091e00-978c-11e9-914c-7ad48306cd94.png)

The title of the reading session "card" is used to expand the panel, so the link to the article must be somewhere else. 
Please let me know if I missunderstood the request, and also do make sure to test properly before deploying - I dont have the Zeeguu Web / Reader running locally, so I can not test that the link actually goes to the right article - but it should :-)  