### PR TITLE
move article link inside expanded panel

### DIFF
--- a/zeeguu-teacher-dashboard/src/assets/styles/pages/studentPage.scss
+++ b/zeeguu-teacher-dashboard/src/assets/styles/pages/studentPage.scss
@@ -15,8 +15,8 @@
 
 .student-activity-item-link {
   color: $color-link;
-  margin-left: 10px;
   font-size: 14px;
+  margin-bottom: 24px;
 }
 
 .student-activity-item-duration {

--- a/zeeguu-teacher-dashboard/src/pages/StudentPage.js
+++ b/zeeguu-teacher-dashboard/src/pages/StudentPage.js
@@ -62,16 +62,6 @@ const StudentActivity = ({ studentId }) => {
                       <h2 className="student-activity-item-heading">
                         {readingSession.article_title}
                       </h2>
-                      <a
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="student-activity-item-link"
-                        href={`/read/article?articleID=${
-                          readingSession.article_id
-                        }`}
-                      >
-                        (→)
-                      </a>
                     </div>
                     <p className="student-activity-item-duration">
                       {sessionDuration(readingSession)}
@@ -83,6 +73,16 @@ const StudentActivity = ({ studentId }) => {
                       flexDirection: 'column'
                     }}
                   >
+                    <a
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="student-activity-item-link"
+                      href={`/read/article?articleID=${
+                        readingSession.article_id
+                      }`}
+                    >
+                      Read article →
+                    </a>
                     {(readingSession.bookmarks.sentence_list.length === 0 && (
                       <p>No words were translated in this reading session.</p>
                     )) ||


### PR DESCRIPTION
Moves the article link inside the expanded panel and add text to describe what the action does (I think the arrow by itself is unclear, and now since we are only showing the link for an expanded panel, we can afford to have some more text in the link).

![image](https://user-images.githubusercontent.com/21239560/60290216-8ddf5780-9918-11e9-936f-cbd4c5eaf598.png)
